### PR TITLE
One more tiny fix: use full path on dep test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install: deps
 	go install ./...
 
 deps:
-	command -v dep >/dev/null || go get -u github.com/golang/dep/cmd/dep
+	command -v $(GOPATH)/bin/dep >/dev/null || go get -u github.com/golang/dep/cmd/dep
 	$(GOPATH)/bin/dep ensure
 
 test: build


### PR DESCRIPTION
Previously, dep was being reinstalled every time because the
check for it wouldn't find it on $PATH.