### PR TITLE
Build the test docker image if necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BIN = die
 all: clean build
 
 run: build
+	docker image ls | grep "die-test" >/dev/null || docker build -t die-test:latest .
 	./build/$(BIN) die-test
 
 build: #deps


### PR DESCRIPTION
Prevents contributors from needing to remember to build the docker image again if contributing on a new machine. 